### PR TITLE
Improve cmake compatibility in cc_fix_config

### DIFF
--- a/config.bzl
+++ b/config.bzl
@@ -39,6 +39,7 @@ def _fix_config_impl(ctx):
 
     script = ""
     for k, v in ctx.attr.values.items():
+        v = v.replace('\\', '\\\\').replace('/', '\\/')
         if ctx.attr.cmake:
             script += r"s/\#cmakedefine\s+%s\b.*/\#define %s %s/g;" % (k, k, v)
             script += r"s/\$\{%s\}/%s/g;" % (k, v)

--- a/config.bzl
+++ b/config.bzl
@@ -40,14 +40,14 @@ def _fix_config_impl(ctx):
     script = ""
     for k, v in ctx.attr.values.items():
         if ctx.attr.cmake:
-            script += "s/\#cmakedefine[\s]+%s([\s]+\$\{%s\})?/\#define %s %s/g;" % (k, k, k, v)
-        else:
-            script += "s/\@%s\@/%s/g;" % (k, v)
+            script += r"s/\#cmakedefine\s+%s\b.*/\#define %s %s/g;" % (k, k, v)
+            script += r"s/\$\{%s\}/%s/g;" % (k, v)
+        script += r"s/\@%s\@/%s/g;" % (k, v)
 
     if ctx.attr.cmake:
-        script += "s/\#cmakedefine[\s]+([^\s]+)([\s]+\$\{.+\})?//g"
-    else:
-        script += "s/\@[^\@]*\@/0/g"
+        script += r"s/\#cmakedefine[\s]+(\w+).*/\/* #undef \1 *\//g;"
+        script += r"s/\$\{\w+\}//g;"
+    script += r"s/\@[^\@]*\@/0/g"
 
     ctx.action(
         inputs = [input],


### PR DESCRIPTION
When cmake == True:

- handles `${KEY}` and `@KEY@` forms
- handle #cmakedefine regardless of text after identifier
- produce comments when removing defines
- use \b to avoid errors when one key a prefix of another

This is closer to the behaviour as documented here:
https://cmake.org/cmake/help/v3.2/command/configure_file.html

And can now handle pcl_config.h.in:
https://github.com/PointCloudLibrary/pcl/blob/405d2bbb99ed5a78dc11c07a08bea9ad19f7cb6a/pcl_config.h.in
producing output similar to this:
http://docs.pointclouds.org/trunk/pcl__config_8h_source.html